### PR TITLE
Allow a new maxepoch when resuming from a checkpoint.

### DIFF
--- a/train.lua
+++ b/train.lua
@@ -396,6 +396,12 @@ if plpath.isfile(lastStatePath) and not config.nosave then
                 state.epoch, state.t, state.epoch_t, state.jumped))
         end
     end
+
+    -- Support modifying the maxepoch setting during resume
+    engine.hooks.onResume = function(state)
+        state.maxepoch = config.maxepoch
+    end
+
     engine:resume{
         path = lastStatePath,
         iterator = corpus.train,


### PR DESCRIPTION
I found this useful when performing hyperparameter sweeps.